### PR TITLE
fixed deprecated methods

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,7 +28,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('check_grants')
                     ->info('If this is set to true, the AbstractCRUDController will use denyAccessUnlessGranted to control access.')
-                    ->cannotBeEmpty()
                     ->defaultValue(false)
                 ->end()
             ->end();

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -29,8 +29,8 @@ services:
     madrak_io_easy_admin.crud_controller:
         abstract: true
         calls:
-            - [ setContainer, [ @service_container ]]
+            - [ setContainer, [ "@service_container" ]]
     madrak_io_easy_admin.dashboard_controller:
         abstract: true
         calls:
-            - [ setContainer, [ @service_container ]]
+            - [ setContainer, [ "@service_container" ]]


### PR DESCRIPTION
fixed some deprecated methods since symfony version 2.8

```
Not quoting the scalar "@service_container " starting with "@" is deprecated since Symfony 2.8 and will throw a ParseException in 3.0: 2x
    2x in AppKernel::boot

The Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition::cannotBeEmpty method is deprecated since version 2.8 and will be removed in 3.0: 1x
    1x in AppKernel::boot
```