### PR TITLE
fixed deprecation notice on abstract controller

### DIFF
--- a/Controller/AbstractCoreCRUDController.php
+++ b/Controller/AbstractCoreCRUDController.php
@@ -88,7 +88,7 @@ abstract class AbstractCoreCRUDController extends AbstractController implements 
 
         $this->denyAccessUnlessGranted(EasyAdminVoterInterface::CREATE, $entity);
 
-        $form = $this->createForm($this->entityFormType, $entity, $this->getCreateFormOptions());
+        $form = $this->createForm(get_class($this->entityFormType), $entity, $this->getCreateFormOptions());
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
@@ -155,7 +155,7 @@ abstract class AbstractCoreCRUDController extends AbstractController implements 
         $this->denyAccessUnlessGranted(EasyAdminVoterInterface::EDIT, $entity);
 
         $deleteForm = $this->createDeleteForm($request, $entity);
-        $editForm = $this->createForm($this->entityFormType, $entity, $this->getEditFormOptions());
+        $editForm = $this->createForm(get_class($this->entityFormType), $entity, $this->getEditFormOptions());
         $editForm->handleRequest($request);
 
         if ($editForm->isSubmitted()) {


### PR DESCRIPTION
## Fixed
```
Passing type instances to FormBuilder::add(), Form::add() or the FormFactory is deprecated since version 2.8 and will not be supported in 3.0. Use the fully-qualified type class name instead
```